### PR TITLE
Potential fix for code scanning alert no. 4: Regular expression injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "mongoose": "^8.9.5",
     "node-schedule": "^2.1.1",
     "octokit": "^4.1.0",
-    "zlib": "^1.0.5"
+    "zlib": "^1.0.5",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/src/models/statistic.ts
+++ b/src/models/statistic.ts
@@ -1,6 +1,7 @@
 import { Document, Model, Schema, model } from 'mongoose';
 import { BotUserDoc } from './botUser';
 import { debug } from '../Log';
+import _ from 'lodash';
 
 export type StatisticFilter = {
     global?: boolean;
@@ -58,7 +59,8 @@ export async function getStatistics(filter?: StatisticFilter): Promise<Statistic
         }
     }
     if (filter?.key !== undefined) {
-        query['key'] = new RegExp("^" + filter.key);
+        const safeKey = _.escapeRegExp(filter.key);
+        query['key'] = new RegExp("^" + safeKey);
     }
     if (filter?.userId !== undefined) {
         query['user'] = filter.userId;


### PR DESCRIPTION
Potential fix for [https://github.com/Racooder/guardian-bot/security/code-scanning/4](https://github.com/Racooder/guardian-bot/security/code-scanning/4)

To fix the problem, we need to sanitize the user input before using it to construct a regular expression. The best way to do this is by using the `_.escapeRegExp` function from the lodash library, which escapes special characters in the input string that have special meaning in regular expressions.

1. Install the lodash package if it is not already installed.
2. Import the lodash library in the relevant file.
3. Use the `_.escapeRegExp` function to sanitize the `filter.key` before constructing the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
