### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "node-schedule": "^2.1.1",
     "octokit": "^4.1.0",
     "zlib": "^1.0.5",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/src/Rest.ts
+++ b/src/Rest.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import cors from 'cors';
+import rateLimit from 'express-rate-limit';
 import { deleteFeedback, getFeedback, listFeedback, updateFeedbackStatus } from './api/Feedback';
 import { getStatistic } from './api/Stats';
 import { config } from './Essentials';
@@ -11,6 +12,15 @@ import { Server } from 'http';
 const app = express();
 app.use(express.json());
 app.use(cors());
+
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
+
+// Apply rate limiter to all requests
+app.use(limiter);
 
 // * Routes
 


### PR DESCRIPTION
Potential fix for [https://github.com/Racooder/guardian-bot/security/code-scanning/3](https://github.com/Racooder/guardian-bot/security/code-scanning/3)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to set up a rate limiter middleware. This middleware will limit the number of requests a client can make within a specified time window, thus protecting the application from being overwhelmed by too many requests.

We will:
1. Install the `express-rate-limit` package.
2. Import the package in the `src/Rest.ts` file.
3. Set up a rate limiter with appropriate configuration.
4. Apply the rate limiter to the routes that perform expensive operations, such as database access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
